### PR TITLE
Fix install script shebang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,1 +1,2 @@
+#!/usr/bin/env bash
 raco pkg install hostname


### PR DESCRIPTION
## Summary
- add a bash shebang to `install.sh`
- ensure newline at EOF

## Testing
- `bash -n install.sh`
- `bash build.sh` *(fails: raco command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419979f8d08320a4e1ea7a701a981f