### PR TITLE
Fix port validation and doc snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```
 wget https://github.com/smallyunet/a-sample-web-server/releases/download/v0.0.7/server-linux.tar.gz
-tar -zxvf server.tar.gz
+tar -zxvf server-linux.tar.gz
 ./server/server
 ```
 

--- a/server.rkt
+++ b/server.rkt
@@ -17,8 +17,12 @@
 
 (define (port-handler p)
   (cond
-    [(boolean? p) "20200"]
-    [(string? p) (string-append p)]))
+    [(boolean? p) 20200]
+    [(string? p)
+     (define n (string->number p))
+     (if (and n (exact-integer? n) (<= 0 n) (<= n 65535))
+         n
+         (error 'port "invalid port number ~a" p))]))
 
 
 (define (printIpAddr)
@@ -35,7 +39,7 @@
           (body (p "Hey out there!")))))
 
 (serve/servlet start
-               #:port (string->number (port-handler (port)))
+               #:port (port-handler (port))
                #:extra-files-paths
                (list (build-path "./"))
                #:listen-ip #f


### PR DESCRIPTION
## Summary
- validate port number in `server.rkt`
- remove redundant string conversion
- correct README installation snippet

## Testing
- `bash -n install.sh`
- `bash -n build.sh`
- `raco pkg install --auto hostname` *(fails: HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841972392a88320aee12e519cbf623d